### PR TITLE
第II部-第19章読破

### DIFF
--- a/xunit.php
+++ b/xunit.php
@@ -59,18 +59,23 @@ class WasRun extends TestCase
  */
 class TestCaseTest extends TestCase
 {
+    private $test;
+
+    public function setUp()
+    {
+        $this->test = new WasRun("testMethod");
+    }
+
     public function testRunning()
     {
-        $test = new WasRun("testMethod");
-        $test->run();
-        assert($test->wasRun);
+        $this->test->run();
+        assert($this->test->wasRun);
     }
 
     public function testSetUp()
     {
-        $test = new WasRun("testMethod");
-        $test->run();
-        assert($test->wasSetUp);
+        $this->test->run();
+        assert($this->test->wasSetUp);
     }
 }
 


### PR DESCRIPTION
- テストをシンプルに書けるほうが、パフォーマンスよりも大事だという意思決定を行った。
- seUpメソッドのテストと実装を行った。
- setUpメソッドを使ってテスト対象コードであるサンプルテストケース(WasRun)をシンプルにした。
- setUpメソッドを使ってサンプルテストケースのチェックを省き、テストコード(TestCaseTest)をシンプルにした(自分で脳外科手術をするようだと言ったのを覚えているだろうか)。