### PR TITLE
Part1 chapter23

### DIFF
--- a/xunit.php
+++ b/xunit.php
@@ -133,33 +133,39 @@ class TestSuite
  */
 class TestCaseTest extends TestCase
 {
+    private $result;
+
+    public function setUp()
+    {
+        $this->result = new TestResult();
+    }
+
     public function testTemplateMethod()
     {
         $test = new WasRun("testMethod");
-        $test->run();
+        $test->run($this->result);
         assert("setUp testMethod tearDown " == $test->log);
     }
 
     public function testResult()
     {
         $test = new WasRun("testMethod");
-        $result = $test->run();
-        assert("1 run, 0 failed" == $result->summary());
+        $test->run($this->result);
+        assert("1 run, 0 failed" == $this->result->summary());
     }
 
     public function testFailedResult()
     {
         $test = new WasRun("testBrokenMethod");
-        $result = $test->run();
-        assert("1 run, 1 failed" == $result->summary());
+        $test->run($this->result);
+        assert("1 run, 1 failed" == $this->result->summary());
     }
 
     public function testFailedResultFormatting()
     {
-        $result = new TestResult();
-        $result->testStarted();
-        $result->testFailed();
-        assert("1 run, 1 failed" == $result->summary());
+        $this->result->testStarted();
+        $this->result->testFailed();
+        assert("1 run, 1 failed" == $this->result->summary());
     }
 
     public function testSuite()
@@ -167,9 +173,8 @@ class TestCaseTest extends TestCase
         $suite = new TestSuite();
         $suite->add(new WasRun("testMethod"));
         $suite->add(new WasRun("testBrokenMethod"));
-        $result = new TestResult();
-        $suite->run($result);
-        assert("2 run, 1 failed" == $result->summary());
+        $suite->run($this->result);
+        assert("2 run, 1 failed" == $this->result->summary());
     }
 }
 

--- a/xunit.php
+++ b/xunit.php
@@ -26,9 +26,8 @@ class TestCase
     {
     }
 
-    public function run()
+    public function run($result)
     {
-        $result = new TestResult();
         $result->testStarted();
         $this->setUp();
         try {
@@ -38,7 +37,6 @@ class TestCase
             $result->testFailed();
         }
         $this->tearDown();
-        return $result;
     }
 
     public function tearDown()
@@ -122,13 +120,11 @@ class TestSuite
         $this->tests[] = $test;
     }
 
-    public function run()
+    public function run($result)
     {
-        $result = new TestResult();
         foreach ($this->tests as $test) {
             $test->run($result);
         }
-        return $result;
     }
 }
 
@@ -171,13 +167,19 @@ class TestCaseTest extends TestCase
         $suite = new TestSuite();
         $suite->add(new WasRun("testMethod"));
         $suite->add(new WasRun("testBrokenMethod"));
-        $result = $suite->run();
+        $result = new TestResult();
+        $suite->run($result);
         assert("2 run, 1 failed" == $result->summary());
     }
 }
 
-(new TestCaseTest("testTemplateMethod"))->run()->summary();
-(new TestCaseTest("testResult"))->run()->summary();
-(new TestCaseTest("testFailedResult"))->run()->summary();
-(new TestCaseTest("testFailedResultFormatting"))->run()->summary();
-(new TestCaseTest("testSuite"))->run()->summary();
+$suite = new TestSuite();
+$suite->add(new TestCaseTest("testTemplateMethod"));
+$suite->add(new TestCaseTest("testResult"));
+$suite->add(new TestCaseTest("testFailedResult"));
+$suite->add(new TestCaseTest("testFailedResultFormatting"));
+$suite->add(new TestCaseTest("testSuite"));
+$result = new TestResult();
+$suite->run($result);
+var_dump($result->summary());
+

--- a/xunit.php
+++ b/xunit.php
@@ -106,6 +106,24 @@ class TestResult
 }
 
 /**
+ * Class TestSuite
+ */
+class TestSuite
+{
+    private $tests;
+
+    public function __construct()
+    {
+        $this->tests = [];
+    }
+
+    public function add($test)
+    {
+        $this->tests[] = $test;
+    }
+}
+
+/**
  * Class TestCaseTest
  */
 class TestCaseTest extends TestCase

--- a/xunit.php
+++ b/xunit.php
@@ -138,9 +138,19 @@ class TestCaseTest extends TestCase
         $result->testFailed();
         assert("1 run, 1 failed" == $result->summary());
     }
+
+    public function testSuite()
+    {
+        $suite = new TestSuite();
+        $suite->add(new WasRun("testMethod"));
+        $suite->add(new WasRun("testBrokenMethod"));
+        $result = $suite->run();
+        assert("2 run, 1 failed" == $result->summary());
+    }
 }
 
 (new TestCaseTest("testTemplateMethod"))->run()->summary();
 (new TestCaseTest("testResult"))->run()->summary();
 (new TestCaseTest("testFailedResult"))->run()->summary();
 (new TestCaseTest("testFailedResultFormatting"))->run()->summary();
+(new TestCaseTest("testSuite"))->run()->summary();

--- a/xunit.php
+++ b/xunit.php
@@ -121,6 +121,15 @@ class TestSuite
     {
         $this->tests[] = $test;
     }
+
+    public function run()
+    {
+        $result = new TestResult();
+        foreach ($this->tests as $test) {
+            $test->run($result);
+        }
+        return $result;
+    }
 }
 
 /**


### PR DESCRIPTION
- TestSuiteのテストを書いた。
- 実装の一部を、テストが失敗したままで作成した。これは明らかにルール違反だった。そのときに気づくことができたなら、手持ちのコードから2つのテストケースをピックアップしただろう。そしてシンプルな仮実装でテストケースを通し、グリーンのままリファクタリングできただろう。ただ、私はそのときには気づけなかった。
- runメソッドのインターフェース変更を行い、個別の要素と要素の集合が同じ動作をするようにした結果、テストは再び通りだした。
- 重複している前準備のコードをsetUpに抽出した。